### PR TITLE
Follow 302 redirection (GitHub Enterprise)

### DIFF
--- a/src/main/groovy/co/riiid/gradle/ReleaseTask.groovy
+++ b/src/main/groovy/co/riiid/gradle/ReleaseTask.groovy
@@ -5,6 +5,7 @@ import groovyx.net.http.Method
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import org.zeroturnaround.zip.ZipUtil
+import org.apache.http.impl.client.LaxRedirectStrategy
 
 class ReleaseTask extends DefaultTask {
 
@@ -17,6 +18,7 @@ class ReleaseTask extends DefaultTask {
         def accept = project.github.getAcceptHeader()
         
         def http = new HttpBuilder(baseUrl)
+        http.client.setRedirectStrategy(new LaxRedirectStrategy())
 
         def path = "/repos/" +
                 "${project.github.owner}/" +


### PR DESCRIPTION
Don't require user intervention on redirect 302. See https://gist.github.com/johnnywey/2578109 and http://stackoverflow.com/questions/2975515/http-builder-groovy-lost-302-redirect-handling.
