### PR TITLE
Do not override existing baseUrl path

### DIFF
--- a/src/main/groovy/co/riiid/gradle/ReleaseTask.groovy
+++ b/src/main/groovy/co/riiid/gradle/ReleaseTask.groovy
@@ -32,7 +32,7 @@ class ReleaseTask extends DefaultTask {
         ]
 
         http.request(Method.POST) {
-            uri.path = path
+            uri.path += path
             requestContentType = ContentType.JSON
             body = postBody
 


### PR DESCRIPTION
GitHub Enterprise API is usually under `https://.../api/v3`. The request shouldn't override the `/api/v3` path.
