### PR TITLE
[DEAD REPO] Fix platform-specific filename splitting

### DIFF
--- a/src/main/groovy/co/riiid/gradle/ReleaseTask.groovy
+++ b/src/main/groovy/co/riiid/gradle/ReleaseTask.groovy
@@ -70,7 +70,7 @@ class ReleaseTask extends DefaultTask {
     public postAssets(uploadUrl, assets, accept) {
         assets.each { asset ->
             def file = new File(asset as String)
-            def name = asset.split('/')[-1]
+            def name = file.name
             if (file.exists() && file.directory) {
                 name += ".zip"
             }


### PR DESCRIPTION
File separator `/` is platform-specific for splitting asset paths, while `file.name` works on all platforms... and also it's used in other places below without any issues.

This resolves https://github.com/riiid/gradle-github-plugin/issues/11.